### PR TITLE
fixed segfault when destroying atlas

### DIFF
--- a/src/czsurface.c
+++ b/src/czsurface.c
@@ -49,6 +49,8 @@ czsurface * czsurface_load(const char * file) {
 }
 
 void czsurface_destroy(czsurface * surface) {
+    if (surface == NULL)
+        return;
     free(surface->pixels);
     czsurface_internal_destroy(surface);
 }


### PR DESCRIPTION
This is only a quick fix and I don't know if there is a bigger problem in the code (I don't think so), but it seems to work.